### PR TITLE
Add index and other placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ None
   -- Or
 
   local map = require("map")
-
   map.setup{
     mode = "default",  -- or `xplr.config.modes.builtin.default`
     key = "M",
@@ -59,20 +58,77 @@ None
     prefer_multi_map = false,
     placeholder = "{}",
     spacer = "{_}",
-    custom_placeholders = {
-      ["{ext}"] = function(node)
-        -- See https://xplr.dev/en/lua-function-calls#node
-        return xplr.util.shell_quote(node.extension)
-      end,
-
-      ["{name}"] = map.placeholders["{name}"],
-    },
+    custom_placeholders = map.placeholders,
   }
 
   -- Type `M` to switch to single map mode.
   -- Then press `tab` to switch between single and multi map modes.
   -- Press `ctrl-o` to edit the command using your editor.
   ```
+
+## Placeholders
+
+Apart from `{}`, the primary placeholder and `{_}`, the spacer, you can also use the following placeholders:
+
+- `{idx}`: 0-based index of the node.
+- `{0idx}`: 0-padded, 0-based index of the node.
+- `{num}`: 1-based index of the node.
+- `{0num}`: 0-padded, 1-based index of the node.
+- `{total}`: Total number of nodes.
+- `{abs}`: Absolute path of the node.
+- `{rel}`: Relative path of the node.
+- `{name}`: Name of the node.
+- `{ext}`: Extension of the node.
+- `{mime}`: Mime essence of the node.
+- `{size}`: Size of the node.
+- `{perm}`: Permissions of the node in octal.
+- `{rwx}`: Permissions of the node in rwx.
+- `{dir}`: Parent directory of the node.
+- `{uid}`: User ID of the node.
+- `{gid}`: Group ID of the node.
+- `{cdate}`: Creation date of the node in YYYY-MM-DD.
+- `{ctime}`: Creation time of the node in HH:MM:SS.
+- `{mdate}`: Last modification date of the node in YYYY-MM-DD.
+- `{mtime}`: Last modification time of the node in HH:MM:SS.
+
+## Custom Placeholders
+
+You can add new custom placeholders, or modify the existing ones via the `placeholders` table.
+
+It is just a function `function(node, meta)` that takes the following arguments and returns a string.
+
+- [node](#node)
+- [meta](#meta)
+
+### node
+
+See [the official documentation](https://xplr.dev/en/lua-function-calls#node).
+
+### meta
+
+It contains the following fields:
+
+- `total`: Total count of the nodes being operated on (used in `{total}`).
+- `index`: 0-based index of the node (used in `{idx}` and `{0idx}`).
+- `number`: 1-based index of the node (used in `{num}` and `{0num}`).
+
+### Example
+
+```lua
+local map = require("map")
+
+-- Add custom placeholders
+map.placeholders["{created}"] = function(node, meta)
+  return xplr.util.shell_quote(os.date("%Y-%m-%d@%H:%M:%S", node.created / 1000000000))
+end
+
+-- Alternatively, compose existing placeholders
+map.placeholders["{modified}"] = function(node, meta)
+  local d = map.placeholders["{mdate}"](node, meta)
+  local t = map.placeholders["{mtime}"](node, meta)
+  return d .. "@" .. t
+end
+```
 
 ## Features
 
@@ -83,4 +139,3 @@ None
 - Visually inspect and interactively edit commands.
 - Use placeholder `{}` and spacer `{_}` to format commands in multi map mode.
 - Use custom placeholders for custom file properties.
-  By detault you get - `{abs}`, `{rel}`, `{name}`, `{ext}`, `{mime}`, `{size}`.


### PR DESCRIPTION
This adds the following new placeholders:

- `{idx}`: 0-based index of the node.
- `{0idx}`: 0-padded, 0-based index of the node.
- `{num}`: 1-based index of the node.
- `{0num}`: 0-padded, 1-based index of the node.
- `{total}`: Total number of nodes.
- `{perm}`: Permissions of the node in octal.
- `{rwx}`: Permissions of the node in rwx.
- `{dir}`: Parent directory of the node.
- `{uid}`: User ID of the node.
- `{gid}`: Group ID of the node.
- `{cdate}`: Creation date of the node in YYYY-MM-DD.
- `{ctime}`: Creation time of the node in HH:MM:SS.
- `{mdate}`: Last modification date of the node in YYYY-MM-DD.
- `{mtime}`: Last modification time of the node in HH:MM:SS.

Custom placeholder functions can now accept an optional second argument for additional metadata, which contains the following fields:

- `index`
- `number`
- `total`

e.g.

```lua
-- # "-" padded number
map.placeholders["{-num}"] = function(_, meta)
  local pad = string.rep("-", #tostring(meta.total) - #tostring(meta.number))
  return quote(pad .. meta.number)
end
```

Also improves the readme documentation.

Closes: https://github.com/sayanarijit/map.xplr/issues/8