### PR TITLE
Remove unnecessary meta.number

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ See [the official documentation](https://xplr.dev/en/lua-function-calls#node).
 It contains the following fields:
 
 - `total`: Total count of the nodes being operated on (used in `{total}`).
-- `index`: 0-based index of the node (used in `{idx}` and `{0idx}`).
-- `number`: 1-based index of the node (used in `{num}` and `{0num}`).
+- `index`: 0-based index of the node (used in `{idx}`, `{0idx}`, `{num}`, `{0num}`).
 
 ### Example
 

--- a/init.lua
+++ b/init.lua
@@ -49,11 +49,12 @@ local placeholders = {
     return quote(pad .. meta.index)
   end,
   ["{num}"] = function(_, meta)
-    return quote(meta.number)
+    return quote(meta.index + 1)
   end,
   ["{0num}"] = function(_, meta)
-    local pad = string.rep("0", #tostring(meta.total) - #tostring(meta.number))
-    return quote(pad .. meta.number)
+    local num = meta.index + 1
+    local pad = string.rep("0", #tostring(meta.total) - #tostring(num))
+    return quote(pad .. num)
   end,
   ["{total}"] = function(_, meta)
     return quote(meta.total)
@@ -131,9 +132,9 @@ local function map_multi(input, nodes, placeholder, custom_placeholders, spacer)
   local rows = {}
   local colwidths = {}
   local total = #nodes
-  for number, node in ipairs(nodes) do
+  for num, node in ipairs(nodes) do
     local cmd = string.gsub(input, placeholder, quote(node.absolute_path))
-    local meta = { index = number - 1, number = number, total = total }
+    local meta = { index = num - 1, total = total }
 
     for p, fn in pairs(custom_placeholders) do
       cmd = string.gsub(cmd, p, fn(node, meta))


### PR DESCRIPTION
This removed the unnecessary `meta.number` field introduced in `0.5.1`