### PR TITLE
Suggest placeholders interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,4 @@ end
 - Visually inspect and interactively edit commands.
 - Use placeholder `{}` and spacer `{_}` to format commands in multi map mode.
 - Use custom placeholders for custom file properties.
+- Interactive placeholder suggestion.


### PR DESCRIPTION
Display the available placeholders interactively as you type `{`. Press up/down or ctrl-n/ctrl-p to go to next/prev suggestion.